### PR TITLE
refactor(Wrap,Room): Contextを削除し異なる方法でSocketを共有/その他細かいリファクタリング

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,8 +14,6 @@ export interface PageProps {
   clearSocket(): void;
 }
 
-export const SocketContext = React.createContext<AppState['socket']>(null);
-
 const App: React.FC = () => {
   const [socket, setSocket] = useStateWithCallbackLazy<AppState['socket']>(null);
 
@@ -50,9 +48,7 @@ const App: React.FC = () => {
 
   return (
     <ThemeProvider theme={theme}>
-      <SocketContext.Provider value={socket}>
-        <Routes getSocket={getSocket} clearSocket={clearSocket} />
-      </SocketContext.Provider>
+      <Routes getSocket={getSocket} clearSocket={clearSocket} />
     </ThemeProvider>
   );
 };

--- a/src/components/YoutubeController/index.tsx
+++ b/src/components/YoutubeController/index.tsx
@@ -2,12 +2,12 @@ import * as React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { State } from '../../store/store';
 import { Presenter } from './Presenter';
-import { SocketContext } from '../../App';
 import YouTube from 'react-youtube';
 import { YouTubePlayer } from 'youtube-player/dist/types';
 //import { PresenterProps } from './Presenter';
 
 export interface YoutubeControllerProps {
+  socket: SocketIOClient.Socket;
   youtubeDisp: YouTubePlayer | undefined;
   videoStatus: number;
 }
@@ -16,8 +16,6 @@ export const YoutubeController: React.FC<YoutubeControllerProps> = (props: Youtu
   const [timed, setTimed] = React.useState<number>(0);
   const [duration, setDuration] = React.useState<number>(0);
   const [statusIcon, setStatusIcon] = React.useState<'play' | 'pause'>('pause');
-
-  const socket = React.useContext(SocketContext);
   let checkTimer: NodeJS.Timeout | null = null;
 
   React.useEffect(() => {
@@ -27,7 +25,7 @@ export const YoutubeController: React.FC<YoutubeControllerProps> = (props: Youtu
         (props) => {
           setTimed(props.youtubeDisp.getCurrentTime());
         },
-        50,
+        150,
         props
       );
     }
@@ -47,7 +45,7 @@ export const YoutubeController: React.FC<YoutubeControllerProps> = (props: Youtu
 
   const sliderOnChange = (changedtime: MouseEvent, value: number | number[]) => {
     if (props.youtubeDisp) {
-      socket?.emit('youtube_seek', value);
+      props.socket?.emit('youtube_seek', value);
       props.youtubeDisp.seekTo(Number(value), true);
       setTimed(Number(value));
     }

--- a/src/components/YoutubeWrap/Presenter.tsx
+++ b/src/components/YoutubeWrap/Presenter.tsx
@@ -6,7 +6,7 @@ import { YoutubeControllerProps } from '../YoutubeController';
 import { Box, Grid } from '@material-ui/core';
 
 export interface PresenterProps {
-  youtubeRef: React.RefObject<YouTube>;
+  socket: SocketIOClient.Socket;
   player: {
     videoId: string;
     onPlay: ({ target, data }: { target: YouTubePlayer; data: number }) => void;
@@ -32,8 +32,8 @@ export const Presenter: React.FC<PresenterProps> = (props: PresenterProps) => {
         {/* 最大化の場合は↓を変更 */}
         <Grid item xs={11}>
           <Box paddingY={3}>
-            <YouTube {...props.player} ref={props.youtubeRef} />
-            <YoutubeController videoStatus={props.videoStatus} youtubeDisp={props.youtubeDisp} />
+            <YouTube {...props.player} />
+            <YoutubeController socket={props.socket} videoStatus={props.videoStatus} youtubeDisp={props.youtubeDisp} />
           </Box>
         </Grid>
       </Grid>

--- a/src/components/YoutubeWrap/index.tsx
+++ b/src/components/YoutubeWrap/index.tsx
@@ -1,74 +1,70 @@
 import * as React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { State } from '../../store/store';
-import { SocketContext } from '../../App';
-import YouTube from 'react-youtube';
 import { YouTubePlayer } from 'youtube-player/dist/types';
 import { Presenter, PresenterProps } from './Presenter';
 
-export const YoutubeWrap: React.FC = () => {
+interface YoutubeWrapProps {
+  socket: SocketIOClient.Socket;
+}
+
+export const YoutubeWrap: React.FC<YoutubeWrapProps> = (props: YoutubeWrapProps) => {
   const [videoId, setVideoId] = React.useState<string>('');
-
-  // YoutubeControllerに渡すYoutubeイベント
-  const [youtubeDisp, setDisp] = React.useState<PresenterProps['youtubeDisp']>(undefined);
-
-  // YouTubeコンポーネントのステータスが変更された時に変更される
-  const [videoStatus, setVideoStatus] = React.useState<number>(-1);
-
+  const socket = props.socket;
+  const [youtubeDisp, setDisp] = React.useState<PresenterProps['youtubeDisp']>(undefined); // youtube target
+  const [videoStatus, setVideoStatus] = React.useState<number>(-1); // YouTubeコンポーネントのステータスが変更された時に変更される
   const [playingData, setPlayingData] = React.useState<{ movie_id?: string; time: number; isPlaying: boolean }>({
     time: 0,
     isPlaying: false
   });
-
-  // 動画URL入力フォームの値
-  const [candidateId, setCandidate] = React.useState<string>('');
-
-  // 参加時かどうかのフラグ
-  const [isFirst, setIsFirst] = React.useState<boolean>(true);
-
-  const youtubeRef = React.createRef<YouTube>();
-  const socket = React.useContext(SocketContext);
-  const room = useSelector((state: State) => state.room);
+  const [candidateId, setCandidate] = React.useState<string>(''); // 動画URL入力フォームの値
+  const [isFirst, setIsFirst] = React.useState<boolean>(true); // 参加時かどうかのフラグ
+  // const room = useSelector((state: State) => state.room);
 
   React.useEffect(() => {
-    if (socket) {
-      // socketに接続した時の処理
-      if (room.roomId) {
-        // roomIdがセットされているときListennerをセット
-        setUpSocketListenner();
-        // youtubeSync(socket);
+    socket.on('new_playing_data', (res: { movie_id?: string; time: number; isPlaying: boolean }) => {
+      console.log('newplayingData', res);
+      if (res.movie_id) {
+        setVideoId(res.movie_id);
       }
-    }
-  }, [socket, room.roomId, youtubeRef]);
+      setPlayingData(res);
+    });
+  }, []);
+
+  React.useEffect(() => {
+    setUpSocketListenner();
+  }, [youtubeDisp]);
 
   // socket client Listennerを設定
   const setUpSocketListenner = () => {
     if (!socket) return;
-    const events = ['youtube_pause', 'youtube_play', 'youtube_seek', 'request_playing_data', 'new_playing_data'];
+    const events = ['youtube_pause', 'youtube_play', 'youtube_seek', 'request_playing_data'];
     for (const event of events) {
       socket.off(event);
     }
     socket.on('youtube_pause', (time: number) => {
-      getPlayer()?.pauseVideo();
-      getPlayer()?.seekTo(time, true);
-      // console.log('listen!pause!', time, getPlayer());
+      youtubeDisp?.pauseVideo();
+      youtubeDisp?.seekTo(time, true);
+      //console.log('listen!pause!', time, youtubeDisp);
     });
 
     socket.on('youtube_play', (time: number) => {
-      getPlayer()?.playVideo();
-      // console.log('listen!play!', time, youtubeRef);
+      youtubeDisp?.playVideo();
+      //console.log('listen!play!', time, youtubeDisp);
     });
 
     socket.on('youtube_seek', (time: number) => {
-      getPlayer()?.seekTo(time, true);
+      youtubeDisp?.seekTo(time, true);
     });
 
     socket.on('request_playing_data', async (participant_id: string) => {
-      const time = await getPlayer()?.getCurrentTime();
+      const status = youtubeDisp?.getPlayerState();
+      const time = youtubeDisp?.getCurrentTime();
       const playingData: { movie_id?: string; time: number; isPlaying: boolean } = {
         time: time || 0.0,
-        isPlaying: statusCheck(videoStatus)
+        isPlaying: status ? statusCheck(status) : false
       };
+      // console.log('プレイングデータをemitします', playingData);
       if (videoId) {
         playingData.movie_id = videoId;
       }
@@ -78,25 +74,13 @@ export const YoutubeWrap: React.FC = () => {
       };
       socket.emit('send_playing_data', payload);
     });
-
-    socket.on('new_playing_data', (res: { movie_id?: string; time: number; isPlaying: boolean }) => {
-      console.log('newplayingData', res);
-      if (res.movie_id) {
-        setVideoId(res.movie_id);
-      }
-      setPlayingData(res);
-    });
-  };
-
-  const getPlayer = (): YouTubePlayer | undefined => {
-    return youtubeRef.current?.getInternalPlayer();
   };
 
   // ステータスナンバーから再生中か停止中かを返す
-  const statusCheck = (status: number): boolean => {
+  const statusCheck = (value: number): boolean => {
     // https://developers.google.com/youtube/iframe_api_reference?hl=ja#Adding_event_listener 参照
     let isPlaying = false;
-    switch (status) {
+    switch (value) {
       case -1: // 未開始
         isPlaying = false;
         break;
@@ -131,33 +115,30 @@ export const YoutubeWrap: React.FC = () => {
       socket.emit('youtube_pause', target.getCurrentTime());
     },
     onReady: (event: { target: YouTubePlayer }) => {
-      event.target.mute();
-      event.target.getOptions();
-      setDisp(event.target);
-      event.target.cueVideoById('b6-2P8RgT0A');
-      event.target.playVideo();
-      window.setTimeout(
-        (target: YouTubePlayer) => {
-          event.target.seekTo(playingData.time, true);
-          if (playingData.isPlaying) {
-            event.target.playVideo();
-          } else {
-            event.target.pauseVideo();
-          }
+      const { target } = event;
+      target.mute();
+      target.getOptions();
+      setDisp(target);
+      target.cueVideoById('b6-2P8RgT0A');
+      target.playVideo();
+      window.setTimeout(() => {
+        target.pauseVideo();
+        target.seekTo(playingData.time, true);
+        // エージェントごとの処理
+        const agent = window.navigator.userAgent.toLowerCase();
+        if (!agent.match('firefox')) {
+          target.unMute();
+        }
+        if (playingData.isPlaying) {
+          target.playVideo();
+        }
+        window.setTimeout(() => {
           setIsFirst(false);
-        },
-        500,
-        event.target
-      );
-      // FireFoxの場合
-      const agent = window.navigator.userAgent.toLowerCase();
-      if (!agent.match('firefox')) {
-        event.target.unMute();
-      }
+        }, 200);
+      }, 1000);
     },
     onStateChange: ({ target, data }: { target: YouTubePlayer; data: number }) => {
-      console.log('onStateChange');
-      console.log(data);
+      // console.log('onStateChange', data);
       setVideoStatus(data);
     },
     // https://developers.google.com/youtube/player_parameters?hl=ja ここ参照してる
@@ -183,7 +164,7 @@ export const YoutubeWrap: React.FC = () => {
     <React.Fragment>
       <input type="text" value={candidateId} onChange={(e) => setCandidate(e.target.value)} />
       <button onClick={() => handler()}>変更</button>
-      <Presenter player={player} youtubeRef={youtubeRef} videoStatus={videoStatus} youtubeDisp={youtubeDisp} />
+      <Presenter socket={socket} player={player} videoStatus={videoStatus} youtubeDisp={youtubeDisp} />
     </React.Fragment>
   );
 };

--- a/src/pages/Room/Presenter.tsx
+++ b/src/pages/Room/Presenter.tsx
@@ -3,7 +3,11 @@ import { Box, Grid } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import { YoutubeWrap } from '../../components/YoutubeWrap';
 
-export const Presenter: React.FC = () => {
+interface PresenterProps {
+  socket: SocketIOClient.Socket | null;
+}
+
+export const Presenter: React.FC<PresenterProps> = (props: PresenterProps) => {
   return (
     <React.Fragment>
       <div style={{ background: '#fff' }}>
@@ -11,9 +15,7 @@ export const Presenter: React.FC = () => {
       </div>
       <Grid container justify="center">
         <Grid item xs={12}>
-          <Box>
-            <YoutubeWrap />
-          </Box>
+          <Box>{props.socket && <YoutubeWrap socket={props.socket} />}</Box>
         </Grid>
       </Grid>
     </React.Fragment>

--- a/src/pages/Room/index.tsx
+++ b/src/pages/Room/index.tsx
@@ -8,14 +8,15 @@ import { PageProps } from '../../App';
 import './main.css';
 
 const Room: React.FC<PageProps> = (props: PageProps) => {
+  const [socket, setSocket] = React.useState<SocketIOClient.Socket | null>(null);
   const [mount, mountKeeper] = React.useState(null);
   const room = useSelector((state: State) => state.room);
   const history = useHistory();
   const dispach = useDispatch();
-  console.log(room);
 
   React.useEffect(() => {
-    props.getSocket().then((socket) => {
+    props.getSocket().then((rec_socket) => {
+      setSocket(rec_socket);
       // 後でここにルーム存在確認処理を追加
       // ルーム作成ではない場合
       if (!room.roomId) {
@@ -24,7 +25,7 @@ const Room: React.FC<PageProps> = (props: PageProps) => {
         if (roomId) {
           // ルーム入出処理
           // 後でユーザネーム登録処理と一緒に切り離す
-          joinRoom(socket, { roomId });
+          joinRoom(rec_socket, { roomId });
         }
       }
     });
@@ -33,8 +34,9 @@ const Room: React.FC<PageProps> = (props: PageProps) => {
     };
   }, [mountKeeper]);
 
-  const joinRoom = (socket: SocketIOClient.Socket, option: { roomId: string }) => {
-    socket.emit('join_room', { room_id: option.roomId, user_name: 'guest' }, (res: boolean) => {
+  const joinRoom = (socket_rec: SocketIOClient.Socket, option: { roomId: string }) => {
+    if (!socket_rec) return console.log('room :', 'socketがnullだよ', socket_rec);
+    socket_rec.emit('join_room', { room_id: option.roomId, user_name: 'guest' }, (res: boolean) => {
       console.log('入出', res);
       if (res) {
         dispach(roomModule.actions.setRoom({ roomId: option.roomId, isOwner: false }));
@@ -51,7 +53,7 @@ const Room: React.FC<PageProps> = (props: PageProps) => {
     return value;
   };
 
-  return <Presenter />;
+  return <Presenter socket={socket} />;
 };
 
 export default Room;


### PR DESCRIPTION
# 内容
🖊️ 参加時、ルームマスターの再生状況によってYouTubeコンポーネントのonReadyで初期のバッファー読み込み処理をするか処理を分けました。

🖊️ WrapコンポーネントのuseEffectの依存を減らすことでより読みやすいコードにしました。

🖊️ Appコンポーネントのsocket Contextを削除しました。今後はAppコンポーネントのstateのsocketを専用関数の`getSocket`で入手します。

🖊️ Rooｍコンポーネントは`getSocket`関数を使って入手したsocketをYoutubeWrapコンポーネントにpropsとして渡すようにしました。

🖊️ YoutubeWrapコンポーネントの中でセットするsocketリスナーの `new_playing_data` を初期マウント時のみセットするようにしました。(内部に関数、変数の依存をはらんでいないため)

