### PR TITLE
feat&fix(Wrap,Room): 入出者、退出者通知を表示する/参加時は動画をミュート状態に変更

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16438,6 +16438,15 @@
         "sort-keys": "^1.0.0"
       }
     },
+    "notistack": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/notistack/-/notistack-1.0.5.tgz",
+      "integrity": "sha512-xCMG0OhzEdczmDs2lDABEiphKQMZUavdOIRAJhfIcyJkCA4UqBDANL3YCLt+mz8VbAPCeKTn76kbCmYQIqksnA==",
+      "requires": {
+        "clsx": "^1.1.0",
+        "hoist-non-react-statics": "^3.3.0"
+      }
+    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/node": "^12.20.7",
     "@types/react": "^17.0.3",
     "@types/react-dom": "^17.0.3",
+    "notistack": "^1.0.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-redux": "^7.2.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { ThemeProvider } from '@material-ui/styles';
 import { theme } from './config/theme';
 import { Routes } from './config/route';
 import { useStateWithCallbackLazy } from 'use-state-with-callback';
+import { SnackbarProvider } from 'notistack';
 
 interface AppState {
   socket: SocketIOClient.Socket | null;
@@ -48,7 +49,9 @@ const App: React.FC = () => {
 
   return (
     <ThemeProvider theme={theme}>
-      <Routes getSocket={getSocket} clearSocket={clearSocket} />
+      <SnackbarProvider maxSnack={1}>
+        <Routes getSocket={getSocket} clearSocket={clearSocket} />
+      </SnackbarProvider>
     </ThemeProvider>
   );
 };

--- a/src/pages/Room/index.tsx
+++ b/src/pages/Room/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { useHistory } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
+import { VariantType, useSnackbar } from 'notistack';
 import roomModule from '../../store/modules/roomModule';
 import { State } from '../../store/store';
 import { Presenter } from './Presenter';
@@ -10,9 +11,12 @@ import './main.css';
 const Room: React.FC<PageProps> = (props: PageProps) => {
   const [socket, setSocket] = React.useState<SocketIOClient.Socket | null>(null);
   const [mount, mountKeeper] = React.useState(null);
+
   const room = useSelector((state: State) => state.room);
   const history = useHistory();
   const dispach = useDispatch();
+
+  const { enqueueSnackbar } = useSnackbar();
 
   React.useEffect(() => {
     props.getSocket().then((rec_socket) => {
@@ -51,6 +55,16 @@ const Room: React.FC<PageProps> = (props: PageProps) => {
     const params = new URLSearchParams(window.location.search);
     const value = params.get(key);
     return value;
+  };
+
+  // sendNotifiction('○○○○が退出しました', 'error');
+  const sendNotifiction = (message: string, variant: VariantType) => {
+    if (screen.width < 600) return;
+    enqueueSnackbar(message, {
+      variant,
+      anchorOrigin: { horizontal: 'center', vertical: 'top' },
+      autoHideDuration: 2000
+    });
   };
 
   return <Presenter socket={socket} />;

--- a/src/pages/Room/index.tsx
+++ b/src/pages/Room/index.tsx
@@ -38,6 +38,16 @@ const Room: React.FC<PageProps> = (props: PageProps) => {
     };
   }, [mountKeeper]);
 
+  React.useEffect(() => {
+    if (!socket) return;
+    socket.on('user_joined', (user: { id: string; name: string }) => {
+      sendNotifiction(user.name + 'が入出しました', 'success');
+    });
+    socket.on('user_left', (user: { id: string; name: string }) => {
+      sendNotifiction(user.name + 'が退出しました', 'error');
+    });
+  }, [socket]);
+
   const joinRoom = (socket_rec: SocketIOClient.Socket, option: { roomId: string }) => {
     if (!socket_rec) return console.log('room :', 'socketがnullだよ', socket_rec);
     socket_rec.emit('join_room', { room_id: option.roomId, user_name: 'guest' }, (res: boolean) => {
@@ -57,7 +67,6 @@ const Room: React.FC<PageProps> = (props: PageProps) => {
     return value;
   };
 
-  // sendNotifiction('○○○○が退出しました', 'error');
   const sendNotifiction = (message: string, variant: VariantType) => {
     if (screen.width < 600) return;
     enqueueSnackbar(message, {


### PR DESCRIPTION
# 内容
✏️ 通知内容とカラーを渡すと画面上部中央に通知することができる`sendNotifiction`関数を実装しました。

✏️ ルームに新規参加者が入出した場合、「○○が入出しました」(緑)を、ルームから退出者が出た場合は、「〇〇が退出しました」(赤)を画面上部中央に通知するようにしました。

🖊️ ミュート状態でない動画の自動再生は数回訪れたドメインでないと行われないのでMicrosoft edge以外はミュートを設定しました。後ほど対策を考えます。

