### PR TITLE
fix(CopyRoomIdButton): パラメータまですべてクリップボードにコピーできていなかった不具合を修正

### DIFF
--- a/src/components/CopyRoomIdButton/index.tsx
+++ b/src/components/CopyRoomIdButton/index.tsx
@@ -6,7 +6,7 @@ import { Presenter } from './Presenter';
  * URLをクリップボードにコピーするボタン
  */
 export const CopyRoomIdButton: React.FC = () => {
-  const [url] = React.useState<string>(window.location.href);
+  const [url] = React.useState<string>(location.href);
   const urlInputRef = React.useRef<HTMLInputElement>(null);
   const { enqueueSnackbar } = useSnackbar();
 

--- a/src/pages/Room/index.tsx
+++ b/src/pages/Room/index.tsx
@@ -71,7 +71,7 @@ const Room: React.FC<PageProps> = (props: PageProps) => {
     if (screen.width < 600) return;
     enqueueSnackbar(message, {
       variant,
-      anchorOrigin: { horizontal: 'center', vertical: 'top' },
+      anchorOrigin: { horizontal: 'left', vertical: 'bottom' },
       autoHideDuration: 2000
     });
   };


### PR DESCRIPTION
# 内容
🖊️ url state の `window.location.href` を `location.href` に変更しました。