### PR TITLE
fix(CopyRoomIdButton): スマホでCopyRoomIdButtonを押した時の意図しない挙動を修正

### DIFF
--- a/src/components/CopyRoomIdButton/index.tsx
+++ b/src/components/CopyRoomIdButton/index.tsx
@@ -17,7 +17,7 @@ export const CopyRoomIdButton: React.FC = () => {
 
     // クリップボードにコピー
     document.execCommand('copy');
-
+    urlInputRef.current?.blur();
     // 通知
     enqueueSnackbar('招待URLをコピーしました。', {
       variant: 'info',


### PR DESCRIPTION
# 内容

🖊️ スマホでCopyRoomIdButtonを押すとテキスト入力フォームが開いてしまう挙動を修正しました。