### PR TITLE
fix(Header): 招待URLでルームに入ったユーザが戻るボタンをクリックしてもなにも起きない現象を修正

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -6,7 +6,7 @@ export const Header: React.FC = () => {
   const history = useHistory();
 
   const backClick = () => {
-    history.goBack();
+    history.push('/');
   };
   return <Presenter backClick={backClick} />;
 };


### PR DESCRIPTION
# 内容

🖊️ historyインスタンスで使用していたメソッドをbackからpushに変更しました。