### PR TITLE
fix(Wrap): PCでもデフォルトがミュート状態になっていた不具合を修正

### DIFF
--- a/src/components/YoutubeWrap/index.tsx
+++ b/src/components/YoutubeWrap/index.tsx
@@ -309,7 +309,7 @@ export class YoutubeWrap extends React.Component<YoutubeWrapProps, YoutubeWrapSt
       window.setTimeout(() => {
         target.pauseVideo();
         target.seekTo(0, true);
-        if (!this.isSmartPhone) {
+        if (!this.isSmartPhone()) {
           this.unMute();
         }
         resolve(true);


### PR DESCRIPTION
# 内容

🖊️ `setUpBuffer`の`isSmartPhone`関数が実行されていなかったので修正しました。