### PR TITLE
fix(Presenter,css): 全体のレイアウト調整

### DIFF
--- a/src/components/AddForm/Presenter.tsx
+++ b/src/components/AddForm/Presenter.tsx
@@ -15,6 +15,7 @@ export const Presenter: React.FC<PresenterProps> = (props: PresenterProps) => {
           fullWidth
           variant="outlined"
           placeholder="YouTube Movie URL"
+          color="secondary"
           style={{ borderRadius: 'none', background: '#f9f9f9', height: '100%' }}
           value={props.videoId}
           onChange={(e) => props.onChange(e.target.value)}

--- a/src/components/CopyRoomIdButton/Presenter.tsx
+++ b/src/components/CopyRoomIdButton/Presenter.tsx
@@ -1,5 +1,6 @@
-import { Button } from '@material-ui/core';
 import * as React from 'react';
+import { Button, Hidden, IconButton } from '@material-ui/core';
+import { Share } from '@material-ui/icons';
 
 interface PresenterProps {
   onClick: () => void;
@@ -13,15 +14,26 @@ export const Presenter: React.FC<PresenterProps> = (props: PresenterProps) => {
       <input
         type="text"
         value={props.url}
+        onChange={() => {
+          /* valueを設定しているとonChangeを設定しないといけないので */
+        }}
         ref={props.inputRef}
         style={{ opacity: 0, height: 1, width: 1, marginLeft: -1, padding: 0, border: 'none' }}
       />
-      <Button
-        {...{ onClick: props.onClick, disableElevation: true, variant: 'contained', color: 'secondary' }}
-        style={{ borderRadius: '1000px' }}
-      >
-        INVITE ROOM
-      </Button>
+      <Hidden xsDown>
+        <Button
+          startIcon={<Share />}
+          {...{ onClick: props.onClick, disableElevation: true, variant: 'contained', color: 'secondary' }}
+          style={{ borderRadius: '1000px' }}
+        >
+          INVITE ROOM
+        </Button>
+      </Hidden>
+      <Hidden smUp>
+        <IconButton {...{ onClick: props.onClick, disableElevation: true, variant: 'contained', color: 'secondary' }}>
+          <Share />
+        </IconButton>
+      </Hidden>
     </React.Fragment>
   );
 };

--- a/src/components/CreateForm/Presenter.tsx
+++ b/src/components/CreateForm/Presenter.tsx
@@ -24,37 +24,39 @@ export const Presenter: React.FC<PresenterProps> = (props: PresenterProps) => {
   return (
     <Card className={classes.form_card}>
       <Grid container justify="center" spacing={1}>
-        <Grid container xs={10} spacing={1}>
-          <Grid item xs={12}>
-            <Box
-              className="create_room_head"
-              display="flex"
-              justifyContent="center"
-              alignItems="center"
-              lineHeight="0px"
-              marginBottom="30px"
-            >
-              <span>{props.head}</span>
-            </Box>
-          </Grid>
-          {props.inputs.map((input: InputSub) => {
-            return (
-              <Grid item xs={12} key={input.label}>
-                <InputText
-                  label={input.label}
-                  error={input.error}
-                  msg={input.msg}
-                  placeholder={input.placeholder}
-                  value={input.value}
-                  onChange={input.onChange}
-                />
-              </Grid>
-            );
-          })}
-          <Grid item xs={12}>
-            <Button fullWidth variant="contained" disableElevation color="secondary" onClick={props.submitEvent}>
-              {props.btn}
-            </Button>
+        <Grid item xs={10}>
+          <Grid container spacing={1}>
+            <Grid item xs={12}>
+              <Box
+                className="create_room_head"
+                display="flex"
+                justifyContent="center"
+                alignItems="center"
+                lineHeight="0px"
+                marginBottom="30px"
+              >
+                <span>{props.head}</span>
+              </Box>
+            </Grid>
+            {props.inputs.map((input: InputSub) => {
+              return (
+                <Grid item xs={12} key={input.label}>
+                  <InputText
+                    label={input.label}
+                    error={input.error}
+                    msg={input.msg}
+                    placeholder={input.placeholder}
+                    value={input.value}
+                    onChange={input.onChange}
+                  />
+                </Grid>
+              );
+            })}
+            <Grid item xs={12}>
+              <Button fullWidth variant="contained" disableElevation color="secondary" onClick={props.submitEvent}>
+                {props.btn}
+              </Button>
+            </Grid>
           </Grid>
         </Grid>
       </Grid>

--- a/src/components/Header/main.css
+++ b/src/components/Header/main.css
@@ -9,7 +9,7 @@
     z-index: 2;
     user-select: none;
     box-sizing: border-box;
-    padding-left: 2px;
+    padding-left: 8px;
 }
 .header_logo > span{
     text-shadow: 2px 2px 3px #eee;

--- a/src/components/Loading/index.tsx
+++ b/src/components/Loading/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { Box, CircularProgress } from '@material-ui/core';
+import './main.css';
 
 /** ローディング画面 */
 export const Loading: React.FC = () => {
@@ -8,7 +9,7 @@ export const Loading: React.FC = () => {
       display="flex"
       justifyContent="center"
       alignItems="center"
-      height="100vh"
+      className="loadBox"
       style={{ background: 'linear-gradient(45deg, #23d5ab,#23a6d5,#ee7752)' }}
     >
       <CircularProgress size={60} style={{ color: '#fff' }} />

--- a/src/components/Loading/main.css
+++ b/src/components/Loading/main.css
@@ -1,0 +1,10 @@
+.loadBox{
+    height: 100vh;
+}
+
+@supports (-webkit-touch-callout: none) {
+    .loadBox {
+      /* Safari用のハック */
+      height: -webkit-fill-available;
+    }
+}

--- a/src/components/YoutubeWrap/Presenter.tsx
+++ b/src/components/YoutubeWrap/Presenter.tsx
@@ -29,7 +29,7 @@ export const Presenter: React.FC<PresenterProps> = (props: PresenterProps) => {
       <Grid container justify="center">
         {/* 最大化の場合は↓を変更 */}
         <Grid item xs={12}>
-          <Box paddingY={1}>
+          <Box style={{ padding: '0 0 10px 0' }}>
             <Grid container>
               <Grid item xs={12} sm={6} md={4} lg={5} xl={4}>
                 <PlayingBoard videoId={props.videoId} />

--- a/src/config/route.tsx
+++ b/src/config/route.tsx
@@ -30,7 +30,7 @@ const routebases: Array<RouteBase> = [
 export const Routes: React.FC<PageProps> = (props) => {
   const makeRoute = (routebase: RouteBase) => {
     return (
-      <Route path={routebase.path} exact={routebase.exact}>
+      <Route path={routebase.path} exact={routebase.exact} key={routebase.name}>
         {routebase.path !== '/' ? <Header /> : false}
         <routebase.component {...props} />
       </Route>

--- a/src/pages/Home/Presenter.tsx
+++ b/src/pages/Home/Presenter.tsx
@@ -23,12 +23,14 @@ export const Presenter: React.FC<PresenterProps> = (props: PresenterProps) => {
   return (
     <div className="base">
       <Grid container justify="center" alignItems="center" className={classes.baseGrid}>
-        <Grid container xs={11} sm={9} md={6} lg={4} xl={3} spacing={6}>
-          <Grid item className="logo" xs={12}>
-            <span>S</span>treaming!!
-          </Grid>
-          <Grid item xs={12}>
-            <CreateForm width="100%" head="ルーム作成" btn="作成" {...props.createForm} />
+        <Grid item xs={11} sm={9} md={6} lg={4} xl={3} style={{ marginBottom: '100px' }}>
+          <Grid container spacing={4}>
+            <Grid item className="logo" xs={12}>
+              <span>S</span>treaming!!
+            </Grid>
+            <Grid item xs={12}>
+              <CreateForm width="100%" head="ルーム作成" btn="作成" {...props.createForm} />
+            </Grid>
           </Grid>
         </Grid>
       </Grid>

--- a/src/pages/Home/main.css
+++ b/src/pages/Home/main.css
@@ -1,12 +1,26 @@
 @import url('https://fonts.googleapis.com/css2?family=Fredoka+One&display=swap');
-.base {
+
+body{
     position: relative;
-    width: 100%;
     height: 100vh;
+}
+
+.base {
+    position: absolute;
+    top: 0;
+    width: 100%;
+    height: 100%;
     opacity: 1;
     animation: gradient 12s ease infinite , fadein 1.4s ease;
     background: linear-gradient(45deg, #23d5ab,#23a6d5,#ee7752 );
     background-size: 190% 190%;
+}
+
+@supports (-webkit-touch-callout: none) {
+    body {
+      /* Safari用のハック */
+      height: -webkit-fill-available;
+    }
 }
 
 @keyframes fadein {
@@ -25,6 +39,7 @@
     position: relative;
     font-size: 60px;
     color: #fff;
+    user-select: none;
     z-index: 2;
     text-align: center;
 }
@@ -45,6 +60,7 @@
 @media screen and (max-width: 450px) {
     .logo{
         font-size: 40px;
+        letter-spacing: 0px;
     }
     .logo > span{
         font-size: 60px;

--- a/src/pages/Room/Presenter.tsx
+++ b/src/pages/Room/Presenter.tsx
@@ -21,13 +21,13 @@ export const Presenter: React.FC<PresenterProps> = (props: PresenterProps) => {
   return (
     <React.Fragment>
       {props.room.roomId && props.socket ? (
-        <Grid container justify="center" style={{ paddingBottom: '50px' }}>
-          <Grid item xs={11} lg={9} xl={10}>
+        <Grid container justify="center" className="RoomContainer">
+          <Grid item xs={11} lg={9} xl={9}>
             <Box>
               <YoutubeWrap socket={props.socket} room={props.room} />
             </Box>
           </Grid>
-          <Grid item xs={11} lg={9} xl={10}>
+          <Grid item xs={11} lg={9} xl={9}>
             <Box boxSizing="border-box" padding="10px 11px" borderRadius="2px" style={{ background: '#fff' }}>
               <AddForm socket={props.socket} />
             </Box>

--- a/src/pages/Room/main.css
+++ b/src/pages/Room/main.css
@@ -1,9 +1,9 @@
 body{
-    background-color: #373739;
+    background-color: #1f1f1f;
 }
 
 .base {
-    position: relative;
+    position: absolute;
     width: 100%;
     height: 100vh;
     opacity: 1;
@@ -11,6 +11,22 @@ body{
     background: linear-gradient(45deg, #23d5ab,#23a6d5,#ee7752 );
     background-size: 190% 190%;
 }
+
+@supports (-webkit-touch-callout: none) {
+    body{
+      height: -webkit-fill-available;
+    }
+    .base {
+      /* Safari用のハック */
+      height: -webkit-fill-available;
+    }
+}
+
+.RoomContainer{
+    padding-bottom: '10px';
+    box-sizing: 'border-box';
+}
+
 @keyframes gradient {
 0% {
     background-position: 0% 50%;


### PR DESCRIPTION
# 内容

## 1.0リリースに向けてレスポンシブを含めたレイアウト調整を行いました。

🖊️ スマホのChrome、safariで高さ100vhがヘッダー部と下のメニューを含めた数値になってい不具合を修正しました。

🖊️ ホーム画面のロゴとルーム作成フォームの位置を調整しました。

🖊️ Gridで発生していたエラーを修正しました。

🖊️ ルームの背景色を変更しました。

🖊️ ヘッダーの戻るボタンとロゴの位置を少し離しました。

🖊️ デスクトップサイズのYoutubeWrapコンポーネントの横幅を小さくしました。

🖊️ ルームの高さをスクロールできないように調整しました。

🖊️ ルーム招待ボタンのレイアウトを変更し、スマホサイズの時はアイコンのみ表示するようにしました。

![](https://i.imgur.com/whluEH7.png)

# 備考

レイアウト関係のエラーをすべて解消