### PR TITLE
feat(YW,Room,TW,PL): 再生中のデータとPlayListのデータをUIに反映

### DIFF
--- a/src/components/PlayList/Presenter.tsx
+++ b/src/components/PlayList/Presenter.tsx
@@ -6,6 +6,7 @@ import { PlayListItem } from '.';
 
 interface PresenterProps {
   socket: SocketIOClient.Socket;
+  nowPlaying: PlayListItem;
   playList: PlayListItem[];
   isOpen: boolean;
   smartphone?: boolean;
@@ -13,7 +14,7 @@ interface PresenterProps {
 
 export const Presenter: React.FC<PresenterProps> = (props: PresenterProps) => {
   const playList = props.playList;
-  const nowPlaying = playList[0];
+  const nowPlaying = props.nowPlaying;
   return (
     <React.Fragment>
       <div className="movieDetail">
@@ -45,7 +46,7 @@ export const Presenter: React.FC<PresenterProps> = (props: PresenterProps) => {
       </div>
       <div className="movieList" style={{ height: props.isOpen ? '200px' : '0px' }}>
         {props.playList.map((movie, index) => {
-          return index !== 0 ? (
+          return (
             <Grid
               container
               className="movies"
@@ -66,7 +67,7 @@ export const Presenter: React.FC<PresenterProps> = (props: PresenterProps) => {
                     background: 'rgba(0,0,0,0.3)'
                   }}
                 >
-                  {index}
+                  {index + 1}
                 </div>
                 <img
                   src={movie.thumbnail}
@@ -91,8 +92,6 @@ export const Presenter: React.FC<PresenterProps> = (props: PresenterProps) => {
                 <p style={{ margin: '0px', fontSize: '14px', color: '#8f8f8f' }}>{movie.requester} がリクエスト</p>
               </Grid>
             </Grid>
-          ) : (
-            false
           );
         })}
       </div>

--- a/src/components/PlayList/index.tsx
+++ b/src/components/PlayList/index.tsx
@@ -3,6 +3,7 @@ import { Presenter } from './Presenter';
 
 interface PlayListProps {
   socket: SocketIOClient.Socket;
+  nowPlaying: PlayListItem;
   playList: PlayListItem[];
   isOpen: boolean;
   smartphone?: boolean;
@@ -17,6 +18,12 @@ export interface PlayListItem {
 
 export const PlayList: React.FC<PlayListProps> = (props: PlayListProps) => {
   return (
-    <Presenter socket={props.socket} playList={props.playList} isOpen={props.isOpen} smartphone={props.smartphone} />
+    <Presenter
+      socket={props.socket}
+      nowPlaying={props.nowPlaying}
+      playList={props.playList}
+      isOpen={props.isOpen}
+      smartphone={props.smartphone}
+    />
   );
 };

--- a/src/components/TabWrap/index.tsx
+++ b/src/components/TabWrap/index.tsx
@@ -13,6 +13,7 @@ interface TabWrapProps {
     setChatList: React.Dispatch<React.SetStateAction<ChatItem[]>>;
   };
   playList: {
+    nowPlaying: PlayListItem;
     playList: PlayListItem[];
   };
   smartphone?: boolean;

--- a/src/components/YoutubeWrap/index.tsx
+++ b/src/components/YoutubeWrap/index.tsx
@@ -47,6 +47,7 @@ export class YoutubeWrap extends React.Component<YoutubeWrapProps, YoutubeWrapSt
   }
 
   socket = this.props.socket;
+  playList = this.props.playList;
 
   defaultOpts = (isSmartPhone: boolean): YouTubeProps['opts'] => ({
     width: '100%',
@@ -223,7 +224,7 @@ export class YoutubeWrap extends React.Component<YoutubeWrapProps, YoutubeWrapSt
         this.mute();
 
         if (this.props.room.isOwner) {
-          this.changeVideo(target, 'ZCY5JS-nuz0');
+          this.changeVideo(target, this.playList[0].videoId);
         } else {
           this.socket.emit('youtube_sync');
         }
@@ -273,7 +274,7 @@ export class YoutubeWrap extends React.Component<YoutubeWrapProps, YoutubeWrapSt
                 target.setVolume(0);
                 if (this.props.room.isOwner) {
                   if (prev_flag === 0) {
-                    this.changeVideo(target, 'ZCY5JS-nuz0');
+                    this.changeVideo(target, this.playList[0].videoId);
                   }
                 } else {
                   this.socket.emit('youtube_sync');

--- a/src/components/YoutubeWrap/index.tsx
+++ b/src/components/YoutubeWrap/index.tsx
@@ -11,7 +11,7 @@ import { PlayListItem } from '../PlayList';
 interface YoutubeWrapProps {
   socket: SocketIOClient.Socket;
   room: RoomState;
-  playList: PlayListItem[];
+  nowPlaying: PlayListItem;
 }
 
 interface YoutubeWrapState {
@@ -47,7 +47,7 @@ export class YoutubeWrap extends React.Component<YoutubeWrapProps, YoutubeWrapSt
   }
 
   socket = this.props.socket;
-  playList = this.props.playList;
+  nowPlaying = this.props.nowPlaying;
 
   defaultOpts = (isSmartPhone: boolean): YouTubeProps['opts'] => ({
     width: '100%',
@@ -224,7 +224,7 @@ export class YoutubeWrap extends React.Component<YoutubeWrapProps, YoutubeWrapSt
         this.mute();
 
         if (this.props.room.isOwner) {
-          this.changeVideo(target, this.playList[0].videoId);
+          this.changeVideo(target, this.nowPlaying.videoId);
         } else {
           this.socket.emit('youtube_sync');
         }
@@ -274,7 +274,7 @@ export class YoutubeWrap extends React.Component<YoutubeWrapProps, YoutubeWrapSt
                 target.setVolume(0);
                 if (this.props.room.isOwner) {
                   if (prev_flag === 0) {
-                    this.changeVideo(target, this.playList[0].videoId);
+                    this.changeVideo(target, this.nowPlaying.videoId);
                   }
                 } else {
                   this.socket.emit('youtube_sync');
@@ -288,8 +288,14 @@ export class YoutubeWrap extends React.Component<YoutubeWrapProps, YoutubeWrapSt
     onStateChange: ({ target, data }: { target: YouTubePlayer; data: number }) => {
       // console.log('onStateChange', data);
       this.setState({ videoStatus: data });
-    }
+    },
     // https://developers.google.com/youtube/player_parameters?hl=ja ここ参照してる
+    onEnd: ({ target }) => {
+      if (this.props.room.isOwner) {
+        // 動画が終了したことをサーバーに通知
+        // this.socket.emit();
+      }
+    }
   };
 
   /** 動画を変更して setUpBuffer を呼び出す関数 */

--- a/src/components/YoutubeWrap/index.tsx
+++ b/src/components/YoutubeWrap/index.tsx
@@ -6,10 +6,12 @@ import { Presenter } from './Presenter';
 import { YouTubeProps } from 'react-youtube';
 import { RoomState } from '../../store/modules/roomModule';
 import Cookie from 'js-cookie';
+import { PlayListItem } from '../PlayList';
 
 interface YoutubeWrapProps {
   socket: SocketIOClient.Socket;
   room: RoomState;
+  playList: PlayListItem[];
 }
 
 interface YoutubeWrapState {
@@ -221,13 +223,7 @@ export class YoutubeWrap extends React.Component<YoutubeWrapProps, YoutubeWrapSt
         this.mute();
 
         if (this.props.room.isOwner) {
-          target.cueVideoById('ZCY5JS-nuz0');
-          this.setState({ videoId: 'ZCY5JS-nuz0' }, () => {
-            this.setUpBuffer(target).then(() => {
-              // console.log('Buffer完了');
-              this.setState({ isFirst: false });
-            });
-          });
+          this.changeVideo(target, 'ZCY5JS-nuz0');
         } else {
           this.socket.emit('youtube_sync');
         }
@@ -277,13 +273,7 @@ export class YoutubeWrap extends React.Component<YoutubeWrapProps, YoutubeWrapSt
                 target.setVolume(0);
                 if (this.props.room.isOwner) {
                   if (prev_flag === 0) {
-                    target.cueVideoById('ZCY5JS-nuz0');
-                    this.setState({ videoId: 'ZCY5JS-nuz0' }, () => {
-                      this.setUpBuffer(target).then(() => {
-                        // console.log('Buffer完了');
-                        this.setState({ isFirst: false });
-                      });
-                    });
+                    this.changeVideo(target, 'ZCY5JS-nuz0');
                   }
                 } else {
                   this.socket.emit('youtube_sync');
@@ -299,6 +289,17 @@ export class YoutubeWrap extends React.Component<YoutubeWrapProps, YoutubeWrapSt
       this.setState({ videoStatus: data });
     }
     // https://developers.google.com/youtube/player_parameters?hl=ja ここ参照してる
+  };
+
+  /** 動画を変更して setUpBuffer を呼び出す関数 */
+  changeVideo = (target: YouTubePlayer, videoId: string): void => {
+    target.cueVideoById(videoId);
+    this.setState({ videoId }, () => {
+      this.setUpBuffer(target).then(() => {
+        // console.log('Buffer完了');
+        this.setState({ isFirst: false });
+      });
+    });
   };
 
   /** ミュート状態で1秒間再生し、元に戻して一時停止する初期バッファーを読み込むための関数です */

--- a/src/pages/Room/Presenter.tsx
+++ b/src/pages/Room/Presenter.tsx
@@ -34,7 +34,7 @@ export const Presenter: React.FC<PresenterProps> = (props: PresenterProps) => {
         <div className="RoomContainer">
           <div className="movieWrap">
             <div className="movie">
-              <YoutubeWrap socket={props.socket} room={props.room} />
+              <YoutubeWrap socket={props.socket} room={props.room} playList={props.playList.playList} />
             </div>
 
             <div className="chat_desk">

--- a/src/pages/Room/Presenter.tsx
+++ b/src/pages/Room/Presenter.tsx
@@ -23,6 +23,7 @@ interface PresenterProps {
     setChatList: React.Dispatch<React.SetStateAction<ChatItem[]>>;
   };
   playList: {
+    nowPlaying: PlayListItem;
     playList: PlayListItem[];
   };
 }
@@ -34,7 +35,7 @@ export const Presenter: React.FC<PresenterProps> = (props: PresenterProps) => {
         <div className="RoomContainer">
           <div className="movieWrap">
             <div className="movie">
-              <YoutubeWrap socket={props.socket} room={props.room} playList={props.playList.playList} />
+              <YoutubeWrap socket={props.socket} room={props.room} nowPlaying={props.playList.nowPlaying} />
             </div>
 
             <div className="chat_desk">

--- a/src/pages/Room/index.tsx
+++ b/src/pages/Room/index.tsx
@@ -23,6 +23,12 @@ const Room: React.FC<PageProps> = (props: PageProps) => {
   const [enterId, setEnterId] = React.useState<string>('');
   const [load, setLoad] = React.useState<boolean>(false);
   const [chatList, setChatList] = React.useState<ChatItem[]>([]);
+  const [nowPlaying, setNowPlaying] = React.useState<PlayListItem>({
+    videoId: '5fooxt19UvA',
+    thumbnail: 'http://img.youtube.com/vi/5fooxt19UvA/mqdefault.jpg',
+    title: '猫が初めてのチュールタワーに興奮しすぎてこうなったwww',
+    requester: 'amanojs'
+  });
   const [playList, setPlayList] = React.useState<PlayListItem[]>([
     {
       videoId: 'qOqPBTU6s6g',
@@ -196,7 +202,7 @@ const Room: React.FC<PageProps> = (props: PageProps) => {
       nameDialog={nameDialog}
       createForm={{ inputs, load, onSubmit: enterSubmitHandler }}
       chat={{ chatList, setChatList }}
-      playList={{ playList }}
+      playList={{ nowPlaying, playList }}
     />
   );
 };

--- a/src/pages/Room/index.tsx
+++ b/src/pages/Room/index.tsx
@@ -25,9 +25,9 @@ const Room: React.FC<PageProps> = (props: PageProps) => {
   const [chatList, setChatList] = React.useState<ChatItem[]>([]);
   const [playList, setPlayList] = React.useState<PlayListItem[]>([
     {
-      videoId: '6LgFJZgbPFE',
-      thumbnail: 'http://img.youtube.com/vi/6LgFJZgbPFE/mqdefault.jpg',
-      title: '『１面のボス〈一輪車ボーイ〉って奴』ジャルジャルのネタのタネ【JARUJARUTOWER】',
+      videoId: 'qOqPBTU6s6g',
+      thumbnail: 'http://img.youtube.com/vi/qOqPBTU6s6g/mqdefault.jpg',
+      title: 'リモート面接中にヒゲ剃る奴',
       requester: 'eiyuu'
     },
     {


### PR DESCRIPTION
# 内容

✏️ PlayListのモックデータを追加しました。

🖊️ 現在再生中の動画とプレイリストを分別しました。

🖊️ onReadyの中の 動画を変更してバッファー処理を行ってisFistを立てる処理を関数化しました。

🖊️  現在再生中の動画データnowPlayingを参照して動画を再生するようにしました。

# 備考

* なし